### PR TITLE
feat: add shell completions (bash, zsh, fish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ If you choose to send us feedback about Claude Code, such as transcripts of your
 We have implemented several safeguards to protect your data, including limited retention periods for sensitive information, restricted access to user session data, and clear policies against using feedback for model training.
 
 For full details, please review our [Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms) and [Privacy Policy](https://www.anthropic.com/legal/privacy).
+
+<!-- PR #52: feat: add shell completions (bash, zsh, fish) -->


### PR DESCRIPTION
Adds static completion scripts for tab autocompletion under shell-completions/:
- claude-completions.bash
- claude-completions.zsh
- claude-completions.fish

Note: If the claude binary supported integrated completions, users would simply be able to run:

    source <(claude completion $SHELL)

as is common in many modern CLI tools.

Unfortunately, upstream integration isn’t possible. The client is not open source.

---
_This PR was originally from a fork: **gitmpr/claude-code** (branch: `feat/shell-completion-scripts`)_